### PR TITLE
Default Attribute Bar Setting Improvements

### DIFF
--- a/FoundryTacticalCombat/FoundryTacticalCombat.lua
+++ b/FoundryTacticalCombat/FoundryTacticalCombat.lua
@@ -47,6 +47,9 @@ FTC.defaults			= {
 	-- Frames
 	["EnableXPBar"]				= true,
 	["EnableNameplate"]			= true,
+  ["EnableDefaultCurrentMax"] = true,
+  ["EnableDefaultPercentage"] = true,
+  ["DefaultAttributeTextOpacity"] = 1,
 	["FTC_PlayerFrame"]			= {CENTER,CENTER,-400,300},
 	["FTC_TargetFrame"]			= {CENTER,CENTER,400,275},
 	}

--- a/FoundryTacticalCombat/FoundryTacticalCombat.lua
+++ b/FoundryTacticalCombat/FoundryTacticalCombat.lua
@@ -47,9 +47,9 @@ FTC.defaults			= {
 	-- Frames
 	["EnableXPBar"]				= true,
 	["EnableNameplate"]			= true,
-  ["EnableDefaultCurrentMax"] = true,
-  ["EnableDefaultPercentage"] = true,
-  ["DefaultAttributeTextOpacity"] = 1,
+	["EnableDefaultCurrentMax"] = true,
+	["EnableDefaultPercentage"] = true,
+	["DefaultAttributeTextOpacity"] = 1,
 	["FTC_PlayerFrame"]			= {CENTER,CENTER,-400,300},
 	["FTC_TargetFrame"]			= {CENTER,CENTER,400,275},
 	}

--- a/FoundryTacticalCombat/frames/Controls.lua
+++ b/FoundryTacticalCombat/frames/Controls.lua
@@ -78,12 +78,13 @@ function FTC.Frames:Controls()
 
 	-- ADD LABELS TO DEFAULT FRAMES
 	local stats		= { "Health" , "Stamina" , "Magicka" }
+  local opacity = FTC.vars["DefaultAttributeTextOpacity"] / 100
 	for  i = 1 , #stats , 1 do
 		local parent	= _G["ZO_PlayerAttribute"..stats[i]]
-		local label		= FTC.UI.Label( "FTC_DefaultPlayer"..stats[i] , parent , { parent:GetWidth() , 20 } , {CENTER,CENTER,0,-1} , "ZoFontAnnounceSmall" , nil , {1,1} , nil , false )
+		local label		= FTC.UI.Label( "FTC_DefaultPlayer"..stats[i] , parent , { parent:GetWidth() , 20 } , {CENTER,CENTER,0,-1} , "ZoFontAnnounceSmall" , {1,1,1,opacity} , {1,1} , nil , false )
 	end
 	local parent		= _G["ZO_TargetUnitFramereticleover"]
-	local label			= FTC.UI.Label( "FTC_DefaultTargetHealth" , parent , { parent:GetWidth() , 20 } , {CENTER,CENTER,0,-1} , "ZoFontAnnounceSmall" , nil , {1,1} , nil , false )
+	local label			= FTC.UI.Label( "FTC_DefaultTargetHealth" , parent , { parent:GetWidth() , 20 } , {CENTER,CENTER,0,-1} , "ZoFontAnnounceSmall" , {1,1,1,opacity} , {1,1} , nil , false )
 
 	-- Create ultimate tracker
 	local ultival 		= FTC.UI.Label( "FTC_UltimateLevel" , ActionButton8 , {50,20} , {BOTTOM,TOP,0,-3} , 'ZoFontAnnounceSmall' , nil , {1,2} , nil , false )

--- a/FoundryTacticalCombat/frames/Controls.lua
+++ b/FoundryTacticalCombat/frames/Controls.lua
@@ -78,7 +78,7 @@ function FTC.Frames:Controls()
 
 	-- ADD LABELS TO DEFAULT FRAMES
 	local stats		= { "Health" , "Stamina" , "Magicka" }
-  local opacity = FTC.vars["DefaultAttributeTextOpacity"] / 100
+	local opacity = FTC.vars["DefaultAttributeTextOpacity"] / 100
 	for  i = 1 , #stats , 1 do
 		local parent	= _G["ZO_PlayerAttribute"..stats[i]]
 		local label		= FTC.UI.Label( "FTC_DefaultPlayer"..stats[i] , parent , { parent:GetWidth() , 20 } , {CENTER,CENTER,0,-1} , "ZoFontAnnounceSmall" , {1,1,1,opacity} , {1,1} , nil , false )

--- a/FoundryTacticalCombat/frames/Functions.lua
+++ b/FoundryTacticalCombat/frames/Functions.lua
@@ -79,13 +79,13 @@ end
 	
 	-- Update the default attribute bar
 	local default 	= ( context == "Player" ) and _G["FTC_DefaultPlayer"..attr.name] or _G["FTC_DefaultTargetHealth"]	
-  local defaultText = ""
-  local showPercentage = true
-  if ( FTC.vars.EnableDefaultCurrentMax ) then defaultText = powerValue .. " / " .. powerEffectiveMax end
-  if ( FTC.vars.EnableDefaultPercentage ) then 
-    if ( FTC.vars.EnableDefaultCurrentMax ) then defaultText = defaultText .. " (" .. pct .. "%)"
-    else defaultText = defaultText .. pct .. "%" end
-  end
+	local defaultText = ""
+	local showPercentage = true
+	if ( FTC.vars.EnableDefaultCurrentMax ) then defaultText = powerValue .. " / " .. powerEffectiveMax end
+	if ( FTC.vars.EnableDefaultPercentage ) then 
+		if ( FTC.vars.EnableDefaultCurrentMax ) then defaultText = defaultText .. " (" .. pct .. "%)"
+		else defaultText = defaultText .. pct .. "%" end
+	end
 	default:SetText( defaultText )
 	
 	-- Toggle opacity

--- a/FoundryTacticalCombat/frames/Functions.lua
+++ b/FoundryTacticalCombat/frames/Functions.lua
@@ -79,7 +79,14 @@ end
 	
 	-- Update the default attribute bar
 	local default 	= ( context == "Player" ) and _G["FTC_DefaultPlayer"..attr.name] or _G["FTC_DefaultTargetHealth"]	
-	default:SetText( powerValue .. " / " .. powerEffectiveMax .. " (" .. pct .. "%)")
+  local defaultText = ""
+  local showPercentage = true
+  if ( FTC.vars.EnableDefaultCurrentMax ) then defaultText = powerValue .. " / " .. powerEffectiveMax end
+  if ( FTC.vars.EnableDefaultPercentage ) then 
+    if ( FTC.vars.EnableDefaultCurrentMax ) then defaultText = defaultText .. " (" .. pct .. "%)"
+    else defaultText = defaultText .. pct .. "%" end
+  end
+	default:SetText( defaultText )
 	
 	-- Toggle opacity
 	local alpha = ((( powerType == POWERTYPE_HEALTH and pct == 100 )  or ( FTC.Player.health.pct == 100 )) and not IsUnitInCombat('player')) and 0.5 or 1

--- a/FoundryTacticalCombat/menu/Controls.lua
+++ b/FoundryTacticalCombat/menu/Controls.lua
@@ -29,6 +29,11 @@ function FTC.Menu:Controls()
 		LAM:AddHeader( FTC.Menu.id , "FTC_Settings_FramesHeader", "Unit Frames Settings")	
 		LAM:AddCheckbox( FTC.Menu.id , "FTC_Settings_EnableNameplate", "Show Player Nameplate", "Show your own character's nameplate?", function() return FTC.vars.EnableNameplate end , function() FTC.Menu:Toggle( 'EnableNameplate' ) end )	
 		LAM:AddCheckbox( FTC.Menu.id , "FTC_Settings_EnableXPBar", "Enable Mini Experience Bar", "Show a small experience bar on the player frame?", function() return FTC.vars.EnableXPBar end , function() FTC.Menu:Toggle( 'EnableXPBar' ) end )	
+  else 
+    LAM:AddHeader( FTC.Menu.id , "FTC_Settings_FramesHeader", "Default Frames Settings")
+    LAM:AddCheckbox( FTC.Menu.id , "FTC_Settings_EnableDefaultCurrentMax", "Show (Current / Max)", "Show the current / maximum attribute amount on the default attribute frames?", function() return FTC.vars.EnableDefaultCurrentMax end , function() FTC.Menu:Toggle( 'EnableDefaultCurrentMax' ) end )
+    LAM:AddCheckbox( FTC.Menu.id , "FTC_Settings_EnableDefaultPercentage", "Show Percentage", "Show the attribute amount as a percentage on the default attribute frames?", function() return FTC.vars.EnableDefaultPercentage end , function() FTC.Menu:Toggle( 'EnableDefaultPercentage' ) end )
+    LAM:AddSlider( FTC.Menu.id , "FTC_Settings_DefaultAttributeTextOpacity", "Text Opacity", "Adjust opacity of the default attribute text.", 0, 100, 1, function() return FTC.vars.DefaultAttributeTextOpacity end, function( value ) FTC.Menu:Update( "DefaultAttributeTextOpacity" , value, true) end, true , "Reloads UI" )
 	end
 
 	-- Buffs settings

--- a/FoundryTacticalCombat/menu/Controls.lua
+++ b/FoundryTacticalCombat/menu/Controls.lua
@@ -29,11 +29,11 @@ function FTC.Menu:Controls()
 		LAM:AddHeader( FTC.Menu.id , "FTC_Settings_FramesHeader", "Unit Frames Settings")	
 		LAM:AddCheckbox( FTC.Menu.id , "FTC_Settings_EnableNameplate", "Show Player Nameplate", "Show your own character's nameplate?", function() return FTC.vars.EnableNameplate end , function() FTC.Menu:Toggle( 'EnableNameplate' ) end )	
 		LAM:AddCheckbox( FTC.Menu.id , "FTC_Settings_EnableXPBar", "Enable Mini Experience Bar", "Show a small experience bar on the player frame?", function() return FTC.vars.EnableXPBar end , function() FTC.Menu:Toggle( 'EnableXPBar' ) end )	
-  else 
-    LAM:AddHeader( FTC.Menu.id , "FTC_Settings_FramesHeader", "Default Frames Settings")
-    LAM:AddCheckbox( FTC.Menu.id , "FTC_Settings_EnableDefaultCurrentMax", "Show (Current / Max)", "Show the current / maximum attribute amount on the default attribute frames?", function() return FTC.vars.EnableDefaultCurrentMax end , function() FTC.Menu:Toggle( 'EnableDefaultCurrentMax' ) end )
-    LAM:AddCheckbox( FTC.Menu.id , "FTC_Settings_EnableDefaultPercentage", "Show Percentage", "Show the attribute amount as a percentage on the default attribute frames?", function() return FTC.vars.EnableDefaultPercentage end , function() FTC.Menu:Toggle( 'EnableDefaultPercentage' ) end )
-    LAM:AddSlider( FTC.Menu.id , "FTC_Settings_DefaultAttributeTextOpacity", "Text Opacity", "Adjust opacity of the default attribute text.", 0, 100, 1, function() return FTC.vars.DefaultAttributeTextOpacity end, function( value ) FTC.Menu:Update( "DefaultAttributeTextOpacity" , value, true) end, true , "Reloads UI" )
+	else 
+		LAM:AddHeader( FTC.Menu.id , "FTC_Settings_FramesHeader", "Default Frames Settings")
+		LAM:AddCheckbox( FTC.Menu.id , "FTC_Settings_EnableDefaultCurrentMax", "Show (Current / Max)", "Show the current / maximum attribute amount on the default attribute frames?", function() return FTC.vars.EnableDefaultCurrentMax end , function() FTC.Menu:Toggle( 'EnableDefaultCurrentMax' ) end )
+		LAM:AddCheckbox( FTC.Menu.id , "FTC_Settings_EnableDefaultPercentage", "Show Percentage", "Show the attribute amount as a percentage on the default attribute frames?", function() return FTC.vars.EnableDefaultPercentage end , function() FTC.Menu:Toggle( 'EnableDefaultPercentage' ) end )
+		LAM:AddSlider( FTC.Menu.id , "FTC_Settings_DefaultAttributeTextOpacity", "Text Opacity", "Adjust opacity of the default attribute text.", 0, 100, 1, function() return FTC.vars.DefaultAttributeTextOpacity end, function( value ) FTC.Menu:Update( "DefaultAttributeTextOpacity" , value, true) end, true , "Reloads UI" )
 	end
 
 	-- Buffs settings


### PR DESCRIPTION
Added the following settings when FTC frames are disabled:
- toggle current/max on default attribute bar text
- toggle percentage on default attribute bar text
- slider to change the opacity of default attribute bar text (resets UI)
