### PR TITLE
cleaned typings/grammars + new translations

### DIFF
--- a/FoundryTacticalCombat/lang/de.lua
+++ b/FoundryTacticalCombat/lang/de.lua
@@ -9,7 +9,7 @@ ZO_CreateStringId("FTC_LongInfo",           "Du benutzt Foundry Tactical Combat 
 --[[----------------------------------------------------------
     KEYBINDINGS
   ]]----------------------------------------------------------
-ZO_CreateStringId("SI_BINDING_NAME_TOGGLE_COMBAT_LOG",      "Aktiviere das Kampflog")
+ZO_CreateStringId("SI_BINDING_NAME_TOGGLE_COMBAT_LOG",      "Wechsel zwischen Kampflog/Chat")
 ZO_CreateStringId("SI_BINDING_NAME_DISPLAY_DAMAGE_REPORT",  "Schadensreport anzeigen")
 ZO_CreateStringId("SI_BINDING_NAME_POST_DAMAGE_RESULTS",    "Schadensreport in Chat einfügen")
 
@@ -22,26 +22,26 @@ ZO_CreateStringId("FTC_Menu_NeedReload",    "Veränderungen an dieser Einstellun
 
 local default = ( FTC.Defaults.EnableFrames ) and "Ein" or "Aus"
 ZO_CreateStringId("FTC_Menu_Frames",        "Einheitenfenster aktivieren")
-ZO_CreateStringId("FTC_Menu_FramesDesc",    "Aktiviere das Einheitenfenster, Gruppenfenster und Schlachtzugsfenster. [Standard: "..default.."]")
+ZO_CreateStringId("FTC_Menu_FramesDesc",    "Aktiviert das Spielerfenster, Zielfenster, Gruppenfenster und Schlachtzugsfenster. [Standard: "..default.."]")
 
 local default = ( FTC.Defaults.EnableBuffs ) and "Ein" or "Aus"
-ZO_CreateStringId("FTC_Menu_Buffs",         "Buffs aktivieren")
-ZO_CreateStringId("FTC_Menu_BuffsDesc",     "Aktiviere die Anzeige der aktiven Buffs? [Standard: "..default.."]")
+ZO_CreateStringId("FTC_Menu_Buffs",         "Buffs und Debuffs aktivieren")
+ZO_CreateStringId("FTC_Menu_BuffsDesc",     "Aktiviert die Anzeige der aktiven Buffs und Debuffs. [Standard: "..default.."]")
  
 local default = ( FTC.Defaults.EnableLog ) and "Ein" or "Aus"
 ZO_CreateStringId("FTC_Menu_Log",           "Kampflog aktivieren")
-ZO_CreateStringId("FTC_Menu_LogDesc",       "Aktiviere die Kampflog Anzeige? [Standard: "..default.."]")
+ZO_CreateStringId("FTC_Menu_LogDesc",       "Aktiviert die Kampflog Anzeige. [Standard: "..default.."]")
  
 local default = ( FTC.Defaults.EnableSCT ) and "Ein" or "Aus"
 ZO_CreateStringId("FTC_Menu_SCT",           "Schwebender Kampftext aktivieren") 
-ZO_CreateStringId("FTC_Menu_SCTDesc",       "Aktiviere die Schwebender Kampftext? [Standard: "..default.."]")
+ZO_CreateStringId("FTC_Menu_SCTDesc",       "Aktiviert den schwebenden Kampftext. [Standard: "..default.."]")
 
-local default = ( FTC.Defaults.EnableMeter ) and "Ein" or "Aus"
-ZO_CreateStringId("FTC_Menu_Damage",        "Schadensstatistik aktivieren")
-ZO_CreateStringId("FTC_Menu_DamageDesc",    "Aktiviere die Anzeige der Schadensstatistik? [Standard: "..default.."]")
+local default = ( FTC.Defaults.EnableStats ) and "Ein" or "Aus"
+ZO_CreateStringId("FTC_Menu_Stats",        "Schadensstatistik aktivieren")
+ZO_CreateStringId("FTC_Menu_StatsDesc",    "Aktiviert die Anzeige der Schadensstatistik. [Standard: "..default.."]")
  
 local default = ( FTC.Defaults.EnableHotbar ) and "Ein" or "Aus"
-ZO_CreateStringId("FTC_Menu_Hotbar",        "Aktiviere erweiterte Hotbar")
+ZO_CreateStringId("FTC_Menu_Hotbar",        "Erweiterte Hotbar aktivieren")
 ZO_CreateStringId("FTC_Menu_HotbarDesc",    "Erweiterte Tooltips über der Standardhotbar anzeigen. [Standard: "..default.."]")
 
 ZO_CreateStringId("FTC_Menu_Move",          "UI Elemente bewegen")
@@ -52,21 +52,19 @@ ZO_CreateStringId("FTC_Menu_MoveDesc",      "Die Positionen der einzelnen FTC UI
   ]]----------------------------------------------------------
 
 -- Unit Frames UI
-ZO_CreateStringId("FTC_PF_Label",           "Player Frame")
-ZO_CreateStringId("FTC_TF_Label",           "Target Frame")
-ZO_CreateStringId("FTC_GF_Label",           "Group Frame")
-ZO_CreateStringId("FTC_RF_Label",           "Raid Frame")
+ZO_CreateStringId("FTC_PF_Label",           "Spielerfenster")
+ZO_CreateStringId("FTC_TF_Label",           "Zielfenster")
+ZO_CreateStringId("FTC_GF_Label",           "Gruppen     fenster")
+ZO_CreateStringId("FTC_RF_Label",           "Schlachtzugs      fenster")
 ZO_CreateStringId("FTC_Dead",               "Dead")
 ZO_CreateStringId("FTC_Offline",            "Offline")
 
 -- Unit Frames Menu
 ZO_CreateStringId("FTC_Menu_FHeader",       "Einheitenfenster Einstellungen")
- 
-ZO_CreateStringId("FTC_Menu_FWidth",        "Einheitenfenster Breite")
-ZO_CreateStringId("FTC_Menu_FWidthDesc",    "Ändert die Breite der Einheitenfenster. [Standard: "..FTC.Defaults.FrameWidth.."]")
- 
-ZO_CreateStringId("FTC_Menu_FHeight",       "Einheitenfenster Höhe")
-ZO_CreateStringId("FTC_Menu_FHeightDesc",   "Ändert die Höhe der Einheitenfenster. [Standard: "..FTC.Defaults.FrameHeight.."]")
+ZO_CreateStringId("FTC_Menu_FWidth",       "Spieler- und Zielfenster Breite")
+ZO_CreateStringId("FTC_Menu_FWidthDesc",    "Ändert die Breite des Spieler- und Zielfensters. [Standard: "..FTC.Defaults.FrameWidth.."]")
+ZO_CreateStringId("FTC_Menu_FHeight",      "Spieler- und Zielfenster Höhe")
+ZO_CreateStringId("FTC_Menu_FHeightDesc",   "Ändert die Höhe des Spieler- und Zielfensters. [Standard: "..FTC.Defaults.FrameHeight.."]")
  
 ZO_CreateStringId("FTC_Menu_FOpacIn",       "Deckkraft im Kampf")
 ZO_CreateStringId("FTC_Menu_FOpacInDesc",   "Ändert die Deckkraft der Einheitenfenster während eines Kampfes. [Standard: "..FTC.Defaults.FrameOpacityIn.."]")
@@ -75,48 +73,48 @@ ZO_CreateStringId("FTC_Menu_FOpacOut",      "Deckkraft außerhalb eines Kampfes"
 ZO_CreateStringId("FTC_Menu_FOpacOutDesc",  "Ändert die Deckkraft der Einheitenfenster außerhalb eines Kampfes. Je niedriger desto durchsichtiger. [Standard: "..FTC.Defaults.FrameOpacityOut.."]")
  
 ZO_CreateStringId("FTC_Menu_FFont1",        "Primäre Schriftart")
-ZO_CreateStringId("FTC_Menu_FFont1Desc",    "Ändert die primäre Schriftart der FTC Einheitenfenster. [Standard: "..FTC.UI:TranslateFont(FTC.Defaults.FrameFont1).."]")
+ZO_CreateStringId("FTC_Menu_FFont1Desc",    "Ändert die primäre Schriftart der Einheitenfenster. [Standard: "..FTC.UI:TranslateFont(FTC.Defaults.FrameFont1).."]")
  
 ZO_CreateStringId("FTC_Menu_FFont2",        "Sekundäre Schriftart")
-ZO_CreateStringId("FTC_Menu_FFont2Desc",    "Ändert die sekundäre Schriftart der FTC Einheitenfenster. [Standard: "..FTC.UI:TranslateFont(FTC.Defaults.FrameFont2).."]")
+ZO_CreateStringId("FTC_Menu_FFont2Desc",    "Ändert die sekundäre Schriftart der Einheitenfenster. [Standard: "..FTC.UI:TranslateFont(FTC.Defaults.FrameFont2).."]")
  
 ZO_CreateStringId("FTC_Menu_FFontS",        "Schriftgröße")
-ZO_CreateStringId("FTC_Menu_FFontSDesc",    "Ändert die Schriftgröße der FTC Einheitenfenster. [Standard: "..FTC.Defaults.FrameFontSize.."]")
+ZO_CreateStringId("FTC_Menu_FFontSDesc",    "Ändert die Schriftgröße der Einheitenfenster. [Standard: "..FTC.Defaults.FrameFontSize.."]")
  
 ZO_CreateStringId("FTC_Menu_Exceute",       "Hinrichten Schwelle")
 ZO_CreateStringId("FTC_Menu_ExecuteDesc",   "Ändert den Wert der erreicht werden muss damit ein Alarm angezeigt wird. [Standard: "..FTC.Defaults.ExecuteThreshold.."]")
 
 local default = ( FTC.Defaults.DefaultTargetFrame ) and "Ein" or "Aus"
-ZO_CreateStringId("FTC_Menu_FShowDef",      "Standard Zielanzeige anzeigen")
-ZO_CreateStringId("FTC_Menu_FShowDefDesc",  "Standard ESO Zielanzeige weiterhin anzeigen? [Standard: "..default.."]")
+ZO_CreateStringId("FTC_Menu_FShowDef",      "Standard Zielfenster anzeigen")
+ZO_CreateStringId("FTC_Menu_FShowDefDesc",  "Zeigt das Standard ESO Zielfenster weiterhin an. [Standard: "..default.."]")
  
 local default = ( FTC.Defaults.EnableNameplate ) and "Ein" or "Aus"
 ZO_CreateStringId("FTC_Menu_FShowName",     "Spieler Namen anzeigen")
-ZO_CreateStringId("FTC_Menu_FShowNameDesc", "Eigenen Namen über der FTC Einheitenfenster anzeigen? [Standard: "..default.."]")
+ZO_CreateStringId("FTC_Menu_FShowNameDesc", "Zeigt den eigenen Namen über dem Spielerfenster an. [Standard: "..default.."]")
 
 local default = ( FTC.Defaults.EnableXPBar ) and "Ein" or "Aus"
 ZO_CreateStringId("FTC_Menu_FShowXP",       "Mini Erfahrungsleiste aktivieren")
-ZO_CreateStringId("FTC_Menu_FShowXPDesc",   "Zeige eine kleine Erfahrungsleiste unter dem FTC Spielerelement an? [Standard: "..default.."]")
+ZO_CreateStringId("FTC_Menu_FShowXPDesc",   "Zeigt eine kleine Erfahrungsleiste unter dem Spielerfenster an. [Standard: "..default.."]")
 
 local default = math.floor(FTC.Defaults.FrameHealthColor[1]*255)..","..math.floor(FTC.Defaults.FrameHealthColor[2]*255)..","..math.floor(FTC.Defaults.FrameHealthColor[3]*255)
 ZO_CreateStringId("FTC_Menu_FHealthC",      "Farbe der Lebensleiste")
-ZO_CreateStringId("FTC_Menu_FHealthCDesc",  "Ändert die Farbe der Lebensleiste der FTC Einheitenfenster. [Standard: "..default.."]")
+ZO_CreateStringId("FTC_Menu_FHealthCDesc",  "Ändert die Farbe der Lebensleiste im Spieler- und Zielfenster. [Standard: "..default.."]")
 
 local default = math.floor(FTC.Defaults.FrameMagickaColor[1]*255)..","..math.floor(FTC.Defaults.FrameMagickaColor[2]*255)..","..math.floor(FTC.Defaults.FrameMagickaColor[3]*255)
 ZO_CreateStringId("FTC_Menu_FMagickaC",     "Farbe der Magieleiste")
-ZO_CreateStringId("FTC_Menu_FMagickaCDesc", "Ändert die Farbe der Magieleiste der FTC Einheitenfenster. [Standard: "..default.."]")
+ZO_CreateStringId("FTC_Menu_FMagickaCDesc", "Ändert die Farbe der Magieleiste im Spielerfenster. [Standard: "..default.."]")
  
 local default = math.floor(FTC.Defaults.FrameShieldColor[1]*255)..","..math.floor(FTC.Defaults.FrameShieldColor[2]*255)..","..math.floor(FTC.Defaults.FrameShieldColor[3]*255)
 ZO_CreateStringId("FTC_Menu_FStaminaC",     "Farbe der Ausdauerleiste")
-ZO_CreateStringId("FTC_Menu_FStaminaCDesc", "Ändert die Farbe der Ausdauerleiste der FTC Einheitenfenster. [Standard: "..default.."]")
+ZO_CreateStringId("FTC_Menu_FStaminaCDesc", "Ändert die Farbe der Ausdauerleiste im Spielerfenster. [Standard: "..default.."]")
  
 local default = math.floor(FTC.Defaults.FrameShieldColor[1]*255)..","..math.floor(FTC.Defaults.FrameShieldColor[2]*255)..","..math.floor(FTC.Defaults.FrameShieldColor[3]*255)
 ZO_CreateStringId("FTC_Menu_FShieldC",      "Farbe der Schildleiste")
-ZO_CreateStringId("FTC_Menu_FShieldCDesc",  "Ändert die Farbe der Schildleiste der FTC Einheitenfenster. [Standard: "..default.."]")
+ZO_CreateStringId("FTC_Menu_FShieldCDesc",  "Ändert die Farbe der Schildleiste im Spielerfenster. [Standard: "..default.."]")
 
 local default = ( FTC.Defaults.EnableGroupFrames ) and "Ein" or "Aus"
 ZO_CreateStringId("FTC_Menu_FGroup",        "Gruppenfenster aktivieren")
-ZO_CreateStringId("FTC_Menu_FGroupDesc",    "Das FTC Gruppenfenster wird bei einer Gruppengröße von 4 oder weniger angezeigt. [Standart: "..default.."]")
+ZO_CreateStringId("FTC_Menu_FGroupDesc",    "Das Gruppenfenster wird bei einer Gruppengröße von 4 oder weniger angezeigt. [Standart: "..default.."]")
 
 ZO_CreateStringId("FTC_Menu_FGWidth",       "Gruppenfenster Breite")
 ZO_CreateStringId("FTC_Menu_FGWidthDesc",   "Ändert die Breite des Gruppenfensters. [Standart: "..FTC.Defaults.GroupWidth.."]")
@@ -149,35 +147,35 @@ ZO_CreateStringId("FTC_Menu_FDamageCDesc",  "Die eingestellte Farbe für die Dam
 
 local default = ( FTC.Defaults.EnableRaidFrames ) and "Ein" or "Aus"
 ZO_CreateStringId("FTC_Menu_FRaid",         "Schlachtzugsfenster aktivieren")
-ZO_CreateStringId("FTC_Menu_FRaidDesc",     "Das FTC Schlachtzugsfenster wird bei einer Gruppengröße größer als 4 angezeigt. [Standart: "..default.."]")
+ZO_CreateStringId("FTC_Menu_FRaidDesc",     "Das Schlachtzugsfenster wird bei einer Gruppengröße größer als 4 angezeigt. [Standart: "..default.."]")
 
 ZO_CreateStringId("FTC_Menu_FRWidth",       "Schlachtzugsfenster Höhe")
-ZO_CreateStringId("FTC_Menu_FRWidthDesc",   "Ändert die Höhe des FTC Schlachtzugsfensters. [Standart: "..FTC.Defaults.RaidWidth.."]")
+ZO_CreateStringId("FTC_Menu_FRWidthDesc",   "Ändert die Höhe des Schlachtzugsfensters. [Standart: "..FTC.Defaults.RaidWidth.."]")
 
 ZO_CreateStringId("FTC_Menu_FRHeight",      "Schlachtzugsfenster Breite")
-ZO_CreateStringId("FTC_Menu_FRHeightDesc",  "Ändert die Breite des FTC Schlachtzugsfensters. [Standart: "..FTC.Defaults.RaidHeight.."]")
+ZO_CreateStringId("FTC_Menu_FRHeightDesc",  "Ändert die Breite des Schlachtzugsfensters. [Standart: "..FTC.Defaults.RaidHeight.."]")
 
 ZO_CreateStringId("FTC_Menu_FRFontS",       "Schlachtzugsfenster Schriftgröße")
-ZO_CreateStringId("FTC_Menu_FRFontSDesc",   "Ändert die Schriftgröße für das FTC Schlachtzugsfenster. [Standart: "..FTC.Defaults.RaidFontSize.."]")
+ZO_CreateStringId("FTC_Menu_FRFontSDesc",   "Ändert die Schriftgröße für das Schlachtzugsfenster. [Standart: "..FTC.Defaults.RaidFontSize.."]")
 
 ZO_CreateStringId("FTC_Menu_FReset",        "Zurücksetzen")
-ZO_CreateStringId("FTC_Menu_FResetDesc",    "Setzt die FTC Einheitenfenster zurück auf die Standardwertet.")
+ZO_CreateStringId("FTC_Menu_FResetDesc",    "Setzt die FTC Einheitenfenster zurück auf die Standardwerte.")
  
 --[[----------------------------------------------------------
     BUFF TRACKING
   ]]----------------------------------------------------------
 
 -- Buff Tracking UI
---ZO_CreateStringId("FTC_PB_Label",           "Player Buffs")
---ZO_CreateStringId("FTC_PD_Label",           "Player Debuffs")
---ZO_CreateStringId("FTC_LB_Label",           "L\no\nn\ng\n\nB\nu\nf\nf\ns")
---ZO_CreateStringId("FTC_TB_Label",           "Target Buffs")
---ZO_CreateStringId("FTC_TD_Label",           "Target Debuffs")
-ZO_CreateStringId("FTC_PlayerBuff",         "Spielerr Buff")
+ZO_CreateStringId("FTC_PB_Label",           "Spieler Buffs")
+ZO_CreateStringId("FTC_PD_Label",           "Spieler Debuffs")
+ZO_CreateStringId("FTC_LB_Label",           "e\nw\ni\ng\ne\n\nB\nu\nf\nf\ns")
+ZO_CreateStringId("FTC_TB_Label",           "Ziel Buffs")
+ZO_CreateStringId("FTC_TD_Label",           "Ziel Debuffs")
+ZO_CreateStringId("FTC_PlayerBuff",         "Spieler Buff")
 ZO_CreateStringId("FTC_PlayerDebuff",       "Spieler Debuff")
 
 -- Buff Tracking Menu
-ZO_CreateStringId("FTC_Menu_BHeader",       "Buff-Anzeige Einstellungen")
+ZO_CreateStringId("FTC_Menu_BHeader",       "Buff und Debuff Einstellungen")
 
 ZO_CreateStringId("FTC_BuffFormat0",        "Deaktiviert")
 ZO_CreateStringId("FTC_BuffFormat1",        "Horizontale Ausrichtung")
@@ -212,14 +210,14 @@ ZO_CreateStringId("FTC_Menu_BFontS",        "Schriftgröße")
 ZO_CreateStringId("FTC_Menu_BFontSDesc",    "Ändert die Schriftgröße der FTC Buff Komponente. [Standard: "..FTC.Defaults.BuffsFontSize.."]")
  
 ZO_CreateStringId("FTC_Menu_BReset",        "Zurücksetzen")
-ZO_CreateStringId("FTC_Menu_BResetDesc",    "Setzt die FTC Buff Einstellungen zurück auf die Standardwertet.")
+ZO_CreateStringId("FTC_Menu_BResetDesc",    "Setzt die FTC Buff Einstellungen zurück auf die Standardwerte.")
  
 --[[----------------------------------------------------------
     COMBAT LOG
   ]]----------------------------------------------------------
 
 -- Combat Log UI
-ZO_CreateStringId("FTC_CL_Label",            "Combat Log")
+ZO_CreateStringId("FTC_CL_Label",           "Kampflog")
 
 -- Combat Log Menu
 ZO_CreateStringId("FTC_Menu_LHeader",       "Kampflog Einstellungen")
@@ -234,20 +232,22 @@ ZO_CreateStringId("FTC_Menu_LFontDesc",     "Ändert die Schriftart des FTC Kamp
 ZO_CreateStringId("FTC_Menu_LFontS",        "Schriftgröße")
 ZO_CreateStringId("FTC_Menu_LFontSDesc",    "Ändert die Schriftgröße des FTC Kampflogs. [Standard: "..FTC.Defaults.LogFontSize.."]")
 
---ZO_CreateStringId("FTC_Menu_LOpacity",      "Log Background Opacity")
---ZO_CreateStringId("FTC_Menu_LOpacityDesc",  "Change the opacity of the background of the FTC combat log. [Default: "..FTC.Defaults.LogOpacity.."]")
+ZO_CreateStringId("FTC_Menu_LOpacity",      "Deckkraft des Kampflogs")
+ZO_CreateStringId("FTC_Menu_LOpacityDesc",  "Ändert die Deckkraft vom Hintergrund des FTC Kampflogs. [Default: "..FTC.Defaults.LogOpacity.."]")
  
 ZO_CreateStringId("FTC_Menu_LReset",        "Zurücksetzen")
 ZO_CreateStringId("FTC_Menu_LResetDesc",    "Setzt die FTC Kampflog Einstellungen zurück auf die Standardwertet.")
 
 --[[----------------------------------------------------------
     SCROLLING COMBAT TEXT
-  ]]----------------------------------------------------------
+  
+
+]]----------------------------------------------------------
 
 -- Combat Text UI
---ZO_CreateStringId("FTC_OD_Label",           "Outgoing Damage")
---ZO_CreateStringId("FTC_ID_Label",           "Incoming Damage")
---ZO_CreateStringId("FTC_CA_Label",           "Combat Alerts")
+ZO_CreateStringId("FTC_OD_Label",           "ausgehender Schaden")
+ZO_CreateStringId("FTC_ID_Label",           "eingehender Schaden")
+ZO_CreateStringId("FTC_CA_Label",           "Kampfmeldungen")
 ZO_CreateStringId("FTC_LowHealth",          "Wenig Leben")
 ZO_CreateStringId("FTC_LowMagicka",         "Wenig Magicka")
 ZO_CreateStringId("FTC_LowStamina",         "Wenig Stamina")
@@ -265,7 +265,7 @@ ZO_CreateStringId("FTC_BreakFree",          "Entfesseln")
 ZO_CreateStringId("FTC_Potion",             "Trank verfügbar")
 ZO_CreateStringId("FTC_Ultimate",           "Ultimate verfügbar")
 ZO_CreateStringId("FTC_CombatIn",           "Im Kampf")
---ZO_CreateStringId("FTC_CleanseNow",         "Cleanse Now")
+ZO_CreateStringId("FTC_CleanseNow",         "Jetzt Reinigen")
 ZO_CreateStringId("FTC_CombatOut",          "Kampfende")
 ZO_CreateStringId("FTC_Falling",            "Fallschaden")
 ZO_CreateStringId("FTC_FakeDamage",         "Test Schaden")
@@ -286,26 +286,26 @@ local default = FTC.Defaults.SCTRound and "Enabled" or "Disabled"
 ZO_CreateStringId("FTC_Menu_SRound",        "Schadenswerte verkürzen")
 ZO_CreateStringId("FTC_Menu_SRoundDesc",    "Die Schadenswerte werden aufgerundet, als Beispiel aus 9.543 Schaden wird 9,5k Schaden. [Standart: "..default.."]")
 
-ZO_CreateStringId("FTC_Menu_SSpeed",        "Geschwindigkeit des Lauftextes")
-ZO_CreateStringId("FTC_Menu_SSpeedDesc",    "Ändert die Geschwindigkeit der Schwebender Kampftext, je höher der Wert, umso schneller die Animation. [Standart: "..FTC.Defaults.SCTSpeed.."]")
+ZO_CreateStringId("FTC_Menu_SSpeed",        "Geschwindigkeit des Kampftextes")
+ZO_CreateStringId("FTC_Menu_SSpeedDesc",    "Ändert die Geschwindigkeit des schwebenden Kampftextes, je höher der Wert, umso schneller die Animation. [Standart: "..FTC.Defaults.SCTSpeed.."]")
 
 ZO_CreateStringId("FTC_Menu_SArc",          "Intensität des Bogens")
-ZO_CreateStringId("FTC_Menu_SArcDesc",      "Ändert die Krümmung der Animation im Schwebender Kampftext, höhere Werte generieren eine größere Biegung. [Standart: "..FTC.Defaults.SCTArc.."]")
+ZO_CreateStringId("FTC_Menu_SArcDesc",      "Ändert die Krümmung der Animation im schwebenden Kampftext, höhere Werte generieren eine größere Biegung. [Standart: "..FTC.Defaults.SCTArc.."]")
 
 ZO_CreateStringId("FTC_Menu_SFont1",        "Primäre Schriftart")
-ZO_CreateStringId("FTC_Menu_SFont1Desc",    "Ändert die primäre Schriftart der Schadenswerte im Schwebender Kampftext. [Standart: "..FTC.UI:TranslateFont(FTC.Defaults.SCTFont1).."]")
+ZO_CreateStringId("FTC_Menu_SFont1Desc",    "Ändert die primäre Schriftart der Schadenswerte im schwebenden Kampftext. [Standart: "..FTC.UI:TranslateFont(FTC.Defaults.SCTFont1).."]")
 
 ZO_CreateStringId("FTC_Menu_SFont2",        "Sekundäre Schriftart")
-ZO_CreateStringId("FTC_Menu_SFont2Desc",    "Ändert die sekundäre Schriftart der Fähigkeitsnamen im Schwebender Kampftext. [Standart: "..FTC.UI:TranslateFont(FTC.Defaults.SCTFont2).."]")
+ZO_CreateStringId("FTC_Menu_SFont2Desc",    "Ändert die sekundäre Schriftart der Fähigkeitsnamen im schwebenden Kampftext. [Standart: "..FTC.UI:TranslateFont(FTC.Defaults.SCTFont2).."]")
 
 ZO_CreateStringId("FTC_Menu_SFontS",        "Schriftgröße")
-ZO_CreateStringId("FTC_Menu_SFontSDesc",    "Ändert die Schriftgröße im FTC Schwebender Kampftext. [Standart: "..FTC.Defaults.SCTFontSize.."]")
+ZO_CreateStringId("FTC_Menu_SFontSDesc",    "Ändert die Schriftgröße im schwebenden Kampftext. [Standart: "..FTC.Defaults.SCTFontSize.."]")
 
 ZO_CreateStringId("FTC_Menu_SIconS",        "Symbolgröße")
-ZO_CreateStringId("FTC_Menu_SIconSDesc",    "Ändert die Symbolgröße im FTC Schwebender Kampftext. [Standart: "..FTC.Defaults.SCTIconSize.."]")
+ZO_CreateStringId("FTC_Menu_SIconSDesc",    "Ändert die Symbolgröße im schwebenden Kampftext. [Standart: "..FTC.Defaults.SCTIconSize.."]")
 
 ZO_CreateStringId("FTC_Menu_SCTReset",      "SCT zurücksetzen")
-ZO_CreateStringId("FTC_Menu_SCTResetDesc",  "Setzt die Einstellungen des FTC Schwebender Kampftext zurück auf die Standartwerte.")
+ZO_CreateStringId("FTC_Menu_SCTResetDesc",  "Setzt die Einstellungen des schwebenden Kampftextes zurück auf die Standartwerte.")
 
 --[[----------------------------------------------------------
     DAMAGE STATISTICS


### PR DESCRIPTION
Änderungsgrund:
L12: Der Kampflog wird hier per se nicht aktivert, der Tastenshortcut bestimmt nur den Wechsel zwischen Log und Chat.

25: Ein Einheitenfenster (Unit Frames) beschreibt alle Fensterarten im UI. Ein Spielerfenster (Player Frame) bzw. Zielfenster (Target Frame) kann kein Einheitenfenster sein, es ist ein Teil davon. Auch wenn die englische Beschreibung an einigen Stellen "ungenau" ist, sollte man entsprechend der tatsächlichen Funktion übersetzen.

28-29: Ergänzung der Beschreibung + Tippfehler 
33: Tippfehler
37: Mashup Bereinigung + Tippfehler
39: String ersetzt + Tippfehler
44: Damit es einheitlicher ist...
65-115: siehe Kommentar zu 25 + Bereinigung
275-308: Mashup Bereinigung + Damit es einheitlicher ist...
