### PR TITLE
Update API and version numbers, adjust Welcome text and added "Philgo…

### DIFF
--- a/FoundryTacticalCombat/FoundryTacticalCombat.lua
+++ b/FoundryTacticalCombat/FoundryTacticalCombat.lua
@@ -15,10 +15,10 @@
     (6) Damage Statistics
     (7) Group Frames
 
-    Author:   Atropos
-    Email:    atropos@tamrielfoundry.com
-    Version:  0.71
-    Updated:  9-13-2015
+    Author:   Atropos / Philgo68
+    Email:    atropos@tamrielfoundry.com / philgo68@gmail.com
+    Version:  0.72
+    Updated:  06-MAR-2015
   ]]--
 
 --[[----------------------------------------------------------
@@ -29,7 +29,7 @@
 FTC                     = {}
 FTC.name                = "FoundryTacticalCombat"
 FTC.tag                 = "FTC"
-FTC.version             = 0.71
+FTC.version             = 0.72
 FTC.settings            = 0.60
 FTC.language            = GetCVar("language.2")
 FTC.UI                  = WINDOW_MANAGER:CreateTopLevelWindow( "FTC_UI" )

--- a/FoundryTacticalCombat/FoundryTacticalCombat.txt
+++ b/FoundryTacticalCombat/FoundryTacticalCombat.txt
@@ -1,7 +1,7 @@
 ## Title: Foundry Tactical Combat
 ## Description: A combat enhancement addon designed to give players access to relevant combat data in an easy to process framework which allows them to respond quickly and effectively to evolving combat situations.
-## Version: 0.71
-## APIVersion: 100012
+## Version: 0.72
+## APIVersion: 100014
 ## SavedVariables: FTC_VARS
 ## OptionalDependsOn: LibAddonMenu-2.0
 

--- a/FoundryTacticalCombat/core/controls.lua
+++ b/FoundryTacticalCombat/core/controls.lua
@@ -62,35 +62,25 @@
 		welcome:AddText("|cCC6600Version " .. FTC.version .. " Updates|r")
 
 		-- Register changes
-		local Changes = {
+    local Changes = {
 			
 			[1] = {
 				"General Changes",
-				"Update addon for ESO 2.1 API compatibility.",
-				"Deprecate usage of the EVENT_INVENTORY_ITEM_USED, EVENT_ACTION_SLOT_UPDATED, and EVENT_ACTION_SLOTS_FULL_UPDATE events which are no longer required under the new API.",
+				"Update addon for ESO v2.3 API compatibility.",
 			},
 
 			[2] = {
 				"Buff Tracking",
-				"Refactor buffs component to use additional information provided by the ESO API.",
-				"Develop an exception system for preventing the display of certain undesirable buffs.",
-				"Deprecate buff extensions files, which are no longer needed under the new API!",
-				"Add wider support for buffs that may be reported by the API but not previously recognized by FTC.",
-				"Correct a number of buff related bugs from 0.69 (PTS beta FTC).",
+				"Adjusted target buff tracking to avoid showing buff(s) from a previous target.",
 			},
 
-			[3] = {
-				"Combat Log",
-				"Improve the wording of incoming healing and damage to better indicate the source of that damage or healing.",
+      [3] = {
+				"Going Forward",
+				"We are currently evaluating the Combat Text system added by ZOS, and will be adjusting and enhancing FTC to meld well.  FTC and the standard Combat Text system are a bit redundant, but work together without any problems.  The standard Combat Text system can be managed in Settings/Interface/Combat Text.",
+        "Philgo (of Master Merchant fame) will be joining the FTC development efforts going forward.",
 			},
 
-			[4] = {
-				"Scrolling Combat Text",
-				"Fix bug preventing incoming healing from being displayed in scrolling combat text.",
-				"Restore SCT alert for Sorcerer Crystal Fragments proc.",
-			},
-
-			[5] = {
+      [4] = {
 				"Known Issues",
 				"The new version of FTC buff tracking doesn't currently work well with ground target AoEs. It does not report a duration for these effects because they are not reported by the API. I will need to develop a separate system for tracking GTAOE timers in a future version.",
 			},
@@ -108,5 +98,5 @@
 
 		-- Add closing messages
 		welcome:AddText("|c|r")	
-		welcome:AddText("If you have any feedback, bug reports, or other questions about Foundry Tactical Combat please contact |cCC6600@Atropos|r on the North American PC megaserver or send an email to |cCC6600atropos@tamrielfoundry.com|r. Thank you for using the FTC addon and for your support!")
+		welcome:AddText("If you have any feedback, bug reports, or other questions about Foundry Tactical Combat please contact |cCC6600@Atropos|r or |cCC6600@Philgo68|r on the North American PC megaserver or send an email to |cCC6600atropos@tamrielfoundry.com|r or |cCC6600philgo68@gmail.com|r. Thank you for using the FTC addon and for your support!")
 	end

--- a/FoundryTacticalCombat/lang/de.lua
+++ b/FoundryTacticalCombat/lang/de.lua
@@ -3,7 +3,7 @@
     GERMAN LANGUAGE LOCALIZATION
   ]]----------------------------------------------------------
 ZO_CreateStringId("FTC_Name",               "Foundry Tactical Combat")
-ZO_CreateStringId("FTC_ShortInfo",          "Foundry Tactical Combat by Atropos")
+ZO_CreateStringId("FTC_ShortInfo",          "Foundry Tactical Combat by Atropos / Philgo")
 ZO_CreateStringId("FTC_LongInfo",           "Du benutzt Foundry Tactical Combat Version " .. FTC.version .. " entwickelt von Atropos der Tamriel Foundry.")
 
 --[[----------------------------------------------------------

--- a/FoundryTacticalCombat/lang/en.lua
+++ b/FoundryTacticalCombat/lang/en.lua
@@ -3,7 +3,7 @@
     ENGLISH LANGUAGE LOCALIZATION
   ]]----------------------------------------------------------
 ZO_CreateStringId("FTC_Name",               "Foundry Tactical Combat")
-ZO_CreateStringId("FTC_ShortInfo",          "Foundry Tactical Combat by Atropos")
+ZO_CreateStringId("FTC_ShortInfo",          "Foundry Tactical Combat by Atropos / Philgo")
 ZO_CreateStringId("FTC_LongInfo",           "You are using Foundry Tactical Combat version " .. FTC.version .. " developed by Atropos of Tamriel Foundry.")
 
 --[[----------------------------------------------------------

--- a/FoundryTacticalCombat/lang/fr.lua
+++ b/FoundryTacticalCombat/lang/fr.lua
@@ -3,7 +3,7 @@
     French LANGUAGE LOCALIZATION
   ]]----------------------------------------------------------
 ZO_CreateStringId("FTC_Name",               "Foundry Tactical Combat")
-ZO_CreateStringId("FTC_ShortInfo",          "Foundry Tactical Combat par Atropos")
+ZO_CreateStringId("FTC_ShortInfo",          "Foundry Tactical Combat par Atropos / Philgo")
 ZO_CreateStringId("FTC_LongInfo",           "Vous utilisez la version " .. FTC.version .. " de Foundry Tactical Combat développée par Atropos de Tamriel Foundry.")
 
 --[[----------------------------------------------------------


### PR DESCRIPTION
…"  Please adjust all this as you see fit.  After testing on the PTS, there is no real need to default the FTC Combat text to OFF.  It seems the standard Combat Text is already defaulted OFF, and they actually run fine together from a code and UI standpoint.
